### PR TITLE
Add support for MESSAGE_CONTENT Intent

### DIFF
--- a/src/Intents.ts
+++ b/src/Intents.ts
@@ -19,7 +19,7 @@ export const flags = {
 	MESSAGE_CONTENT: 1 << 15,
 };
 
-export const privileged = flags.GUILD_MEMBERS | flags.GUILD_PRESENCES | flags.GUILD_MESSAGES;
+export const privileged = flags.GUILD_MEMBERS | flags.GUILD_PRESENCES | flags.GUILD_MESSAGES | flags.MESSAGE_CONTENT;
 
 export const all = Object.values(flags).reduce((acc, p) => acc | p, 0);
 

--- a/src/Intents.ts
+++ b/src/Intents.ts
@@ -16,6 +16,7 @@ export const flags = {
 	DIRECT_MESSAGES: 1 << 12,
 	DIRECT_MESSAGE_REACTIONS: 1 << 13,
 	DIRECT_MESSAGE_TYPING: 1 << 14,
+	MESSAGE_CONTENT: 1 << 15,
 };
 
 export const privileged = flags.GUILD_MEMBERS | flags.GUILD_PRESENCES | flags.GUILD_MESSAGES;


### PR DESCRIPTION
Now that this library uses discord api v10 the `MESSAGE_CONTENT` intent should be added to intent flags. 

Although this flag is not documented in the developer documentation [this](https://github.com/discord/discord-api-docs/discussions/4510#discussioncomment-2175019) developer comment mentions what needs to be done for this intent.