### PR TITLE
feat: use new connection property structure

### DIFF
--- a/src/connector/DiscordConnector.ts
+++ b/src/connector/DiscordConnector.ts
@@ -213,9 +213,9 @@ class DiscordConnector extends EventEmitter {
 			d: {
 				token: this.options.token,
 				properties: {
-					$os: process.platform,
-					$browser: "CloudStorm",
-					$device: "CloudStorm"
+					os: process.platform,
+					browser: "CloudStorm",
+					device: "CloudStorm"
 				},
 				large_threshold: this.options.largeGuildThreshold,
 				shard: [this.id, this.options.totalShards || 1],


### PR DESCRIPTION
With the new announcement they did in https://discord.com/developers/docs/change-log#updated-connection-property-field-names they have updated the preferred properties to be send on the identify call

I haven’t had time to test this change yet with the typings (made changes while I was on my phone travelling), but opening their PR as a way to track the issue 