### PR TITLE
Add event switch system & handle HTTP responses

### DIFF
--- a/src/DiscordConnector.ts
+++ b/src/DiscordConnector.ts
@@ -212,7 +212,6 @@ class DiscordConnector extends EventEmitter<ConnectorEvents> {
 	 * @param resume Whether or not the client intends to send an OP 6 RESUME later.
 	 */
 	private async _reconnect(resume = false): Promise<void> {
-		this.betterWs._internal.openRejector?.(connectionError); // If the client is still attempting to connect, but _reconnect is *somehow* called, destroy the request and just try to reconnect.
 		this.reconnecting = resume;
 		await this.betterWs.close(resume ? 4000 : 1012, "reconnecting");
 		if (resume) {


### PR DESCRIPTION
The event switch abstracts over waiting for any of multiple events. It will remove all listeners after any event is emitted.

We also consider any HTTP responses to be errors because we are trying to connect as a WebSocket. If we can connect as a WebSocket, the upgrade event will be emitted, not the response event. So if we see response we should throw. This should handle the Discord gateway being down with a Cloudflare error page or whatever. DiscordConnector should retry connecting if such a situation occurs in the future.

The decision to destroy the req and the socket when a response occurs is based off the code from the WebSocket library: https://github.com/websockets/ws/blob/b92745a9d6760e6b4b2394bfac78cbcd258a8c8d/lib/websocket.js#L1083

Untested, but it typechecks okay!

Feel free to try adding generics and type inference for eventSwitch and parameters for the callback functions. I couldn't do it.