### PR TITLE
Debugging and QOL features

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "author": "wolke <wolke@weeb.sh>",
   "license": "MIT",
   "dependencies": {
-    "denque": "^2.1.0",
     "discord-api-types": "^0.38.11",
     "snowtransfer": "^0.14.2"
   },

--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
   "license": "MIT",
   "dependencies": {
     "denque": "^2.1.0",
-    "discord-api-types": "^0.381",
+    "discord-api-types": "^0.38.11",
     "snowtransfer": "^0.14.2"
   },
   "devDependencies": {
     "@types/node": "^22.15.31",
     "@typescript-eslint/eslint-plugin": "^8.3.0",
-    "@typescript-eslint/paser": "^8.34.0",
+    "@typescript-eslint/parser": "^8.34.0",
     "eslint": "^9.28.0",
     "tsup": "^8.5.0",
     "typedoc": "^0.28.5",

--- a/src/BetterWs.ts
+++ b/src/BetterWs.ts
@@ -19,6 +19,7 @@ import type {
 } from "./Types";
 
 import StateMachine = require("./StateMachine");
+import stateMachineGraph = require("./StateMachineGraph");
 
 /**
  * Call with an emitter and an object of callbacks, and the first event to be emitted will call the callback.
@@ -208,6 +209,9 @@ class BetterWs extends EventEmitter<BWSEvents> {
 							this.emit("debug", "Server didn't respond for a full close in time");
 						}
 					]
+				}],
+				["disconnect", {
+					destination: "disconnected"
 				}]
 			])
 		})
@@ -235,6 +239,10 @@ class BetterWs extends EventEmitter<BWSEvents> {
 		this.sm.defineUniversalTransition("error", "disconnected");
 
 		this.sm.freeze();
+
+		if (process.argv.includes(`--state-machine-graph-betterws`)) {
+			console.log(stateMachineGraph.graph(this.sm));
+		}
 	}
 
 	/**

--- a/src/DiscordConnector.ts
+++ b/src/DiscordConnector.ts
@@ -298,7 +298,7 @@ class DiscordConnector extends EventEmitter<ConnectorEvents> {
 	 */
 	public async resume(): Promise<void> {
 		if (this.betterWs.sm.currentStateName !== "connected") {
-			this.client.emit("error", `Shard ${this.id} was attempting to resume when the ws was not open. Was ${this.betterWs.sm.currentStateName}`);
+			this.client.emit("error", `Shard ${this.id} was attempting to resume when the ws was not open. Current state: ${this.betterWs.sm.currentStateName}`);
 			return this._reconnect(true);
 		}
 		this.client.emit("debug", `Shard ${this.id} is resuming`);
@@ -318,7 +318,7 @@ class DiscordConnector extends EventEmitter<ConnectorEvents> {
 	 */
 	private heartbeat(): void {
 		if (this.betterWs.sm.currentStateName !== "connected") {
-			this.client.emit("error", `Shard ${this.id} was attempting to heartbeat when the ws was not open. Was ${this.betterWs.sm.currentStateName}`);
+			this.client.emit("error", `Shard ${this.id} was attempting to heartbeat when the ws was not open. Current state: ${this.betterWs.sm.currentStateName}`);
 			return void this._reconnect(true);
 		}
 		this.betterWs.sendMessage({ op: OP.HEARTBEAT, d: this.seq === 0 ? null : this.seq });

--- a/src/StateMachine.ts
+++ b/src/StateMachine.ts
@@ -29,11 +29,11 @@ class StateMachine extends EventEmitter<StateMachineEvents> {
 		})
 	}
 
-	private guardEditable() {
+	public guardEditable() {
 		if (!this.editable) throw new Error("tried to edit state machine after machine has been frozen");
 	}
 
-	private guardNotEditable() {
+	public guardNotEditable() {
 		if (this.editable) throw new Error("tried to do transition before machine has been frozen");
 	}
 
@@ -113,7 +113,7 @@ class StateMachine extends EventEmitter<StateMachineEvents> {
 
 		// Enter state
 		this.emit("enter", this.currentStateName)
-		for (const cb of this.states.get(this.currentStateName)!.onLeave) {
+		for (const cb of this.states.get(this.currentStateName)!.onEnter) {
 			cb(event);
 		}
 	}

--- a/src/StateMachineGraph.ts
+++ b/src/StateMachineGraph.ts
@@ -1,0 +1,27 @@
+import StateMachine = require("./StateMachine");
+
+function graph(stateMachine: StateMachine) {
+	stateMachine.guardNotEditable();
+	let output = "digraph {\n";
+	output += "rankdir=LR\n";
+	output += `${stateMachine.currentStateName}\n`;
+	for (const [stateName, state] of stateMachine.states.entries()) {
+		if (state.onEnter.length) {
+			output += `${stateName} [fontcolor=blue]\n`;
+		}
+
+		for (const [transitionName, transition] of state.transitions.entries()) {
+			output += `${stateName} -> ${transition.destination}`;
+			const attrs = [`label="${transitionName}"`];
+			if (transition.onTransition?.length) {
+				attrs.push("color=blue");
+				attrs.push("fontcolor=blue");
+			}
+			output += `[${attrs.join(" ")}]\n`;
+		}
+	}
+	output += "}";
+	return output;
+}
+
+export { graph };

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -36,7 +36,8 @@ export type IClientWSOptions = {
 	compress?: boolean;
 	encoding?: "etf" | "json";
 	headers?: Record<string, any>;
-	bypassBuckets?: boolean
+	bypassBuckets?: boolean;
+	connectThrottle?: number;
 }
 
 export type BWSEvents = {


### PR DESCRIPTION
What's new since we last paired on this:

- pass flag --state-machine-graph-betterws to output dot graph file
- added debug method, can call it manually or it's printed if any state transitions throw an error
- client ws options now has connectThrottle, default is 10e3
- dropped denque as I ended up using an array anyway